### PR TITLE
remove spy-der strict version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ intervaltree>=3.0.1
 numpy>=1.18.1
 click>=7.1.2
 scipy>=1.5.4
-spy-der==0.1.0
+spy-der>=0.1.0


### PR DESCRIPTION
In the original settings, `spy-der`  would be restored to an older version during installation, so I updated this pull request.