### PR TITLE
Changes for version 1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,6 @@ Options:
   --weight-type [rank|custom]     Specify whether to use rank weighting or
                                   provide custom weights  [default: rank]
 
-  --tie-breaking [uniform|all]    Specify whether to assign tied regions to
-                                  all speakers or divide uniformly  [default:
-                                  all]
-
   --second-maximal                If this flag is set, run a second iteration
                                   of the maximal matching for greedy label
                                   mapping  [default: False]

--- a/dover_lap/dover_lap.py
+++ b/dover_lap/dover_lap.py
@@ -82,11 +82,12 @@ def load_rttms(rttm_list: List[str]) -> List[List[Turn]]:
     " greedy label mapping",
 )
 @click.option(
-    "--tie-breaking",
-    type=click.Choice(["uniform", "all"]),
-    default="all",
-    help="Specify whether to assign tied regions to all speakers or divide uniformly",
+    "--voting-method",
+    type=click.Choice(["average"]),
+    default="average",
     show_default=True,
+    help="Choose voting method to use:"
+    " average: use weighted average to combine input RTTMs",
 )
 @click.option(
     "--weight-type",

--- a/dover_lap/libs/uem.py
+++ b/dover_lap/libs/uem.py
@@ -9,12 +9,9 @@ Taken from https://github.com/nryant/dscore
 from collections import defaultdict
 from collections.abc import MutableMapping
 
-import itertools
 import os
 
 from intervaltree import IntervalTree
-
-from .utils import format_float
 
 
 class UEM(MutableMapping):

--- a/dover_lap/src/doverlap.py
+++ b/dover_lap/src/doverlap.py
@@ -2,7 +2,8 @@ import numpy as np
 
 from typing import List, Union, Optional
 
-from dover_lap.libs.turn import Turn
+from dover_lap.libs.turn import Turn, merge_turns
+from dover_lap.libs.utils import is_module_available
 from dover_lap.src.label_mapping import LabelMapping
 from dover_lap.src.label_voting import LabelVoting
 
@@ -16,7 +17,7 @@ class DOVERLap:
         label_mapping: Optional[str] = "greedy",
         sort_first: Optional[bool] = False,
         second_maximal: Optional[bool] = False,
-        tie_breaking: Optional[str] = "uniform",
+        voting_method: Optional[str] = "average",
         weight_type: Optional[str] = "rank",
         dover_weight: Optional[float] = 0.1,
         custom_weight: Optional[List[str]] = None,
@@ -43,8 +44,10 @@ class DOVERLap:
 
         # Label voting stage
         combined_turns_list = LabelVoting.get_combined_turns(
-            mapped_turns_list, file_id, tie_breaking, weights
+            mapped_turns_list, file_id, voting_method, weights
         )
+        # Merge consecutive turns with the same label
+        combined_turns_list = merge_turns(combined_turns_list)
         return combined_turns_list
 
     def __get_ranks(weights: np.array) -> np.array:

--- a/dover_lap/src/label_mapping.py
+++ b/dover_lap/src/label_mapping.py
@@ -1,9 +1,6 @@
-import numpy as np
-import sys
+from typing import List, Dict, Optional
 
-from typing import List, Dict, Tuple, Optional
-
-from dover_lap.libs.utils import groupby, info
+from dover_lap.libs.utils import groupby
 from dover_lap.libs.turn import Turn
 
 from dover_lap.src.mapping import HungarianMap, GreedyMap

--- a/dover_lap/src/mapping/greedy.py
+++ b/dover_lap/src/mapping/greedy.py
@@ -33,7 +33,7 @@ class GreedyMap:
             ]
             weights[i] = -1 * sum([np.sum(x) for x in cur_pairwise_costs])
 
-        label_mapping = self.__apply_maximal_matching(
+        label_mapping = self._apply_maximal_matching(
             cost_tensor,
             get_speaker_keys(turns_list),
         )
@@ -95,7 +95,7 @@ class GreedyMap:
             cost_tensor = np.sum(list(pairwise_costs.values()))
         return cost_tensor, pairwise_costs
 
-    def __apply_maximal_matching(
+    def _apply_maximal_matching(
         self,
         cost_tensor: np.ndarray,
         speakers_dict: Dict[Tuple[int, int], str],
@@ -121,14 +121,14 @@ class GreedyMap:
                 ),
                 file=sys.stderr,
             )
-            sorted_idx_filtered = self.__filter_sorted_index_list(
+            sorted_idx_filtered = self._filter_sorted_index_list(
                 sorted_idx, remaining_idx
             )
 
             # find initial maximal matching
             M_cur = []
             for idx in sorted_idx_filtered:
-                if not self.__contradicts(M_cur, idx):
+                if not self._contradicts(M_cur, idx):
                     M_cur.append(idx)
 
             if self.second_maximal:
@@ -138,7 +138,7 @@ class GreedyMap:
                     change = False
                     for idx in list(M_cur):
                         M_cur.remove(idx)
-                        M_r = self.__find_remaining_maximal_matching(
+                        M_r = self._find_remaining_maximal_matching(
                             M_cur, sorted_idx_filtered
                         )
                         if len(M_r) > 1:
@@ -169,7 +169,7 @@ class GreedyMap:
 
         return label_mapping
 
-    def __find_remaining_maximal_matching(
+    def _find_remaining_maximal_matching(
         self, M: List[Dict[int, int]], idx_list: List[Tuple[int, int]]
     ) -> List[Tuple[int, int]]:
         """
@@ -179,17 +179,17 @@ class GreedyMap:
         """
         S_r = []
         for idx in list(idx_list):
-            if not self.__contradicts(M, idx):
+            if not self._contradicts(M, idx):
                 S_r.append(idx)
 
         M_r = []
         for idx in S_r:
-            if not self.__contradicts(M_r, idx):
+            if not self._contradicts(M_r, idx):
                 M_r.append(idx)
 
         return M_r
 
-    def __filter_sorted_index_list(
+    def _filter_sorted_index_list(
         self, sorted_idx: List[np.ndarray], remaining_idx: List[Tuple[int, int]]
     ) -> List[np.ndarray]:
         """
@@ -207,7 +207,7 @@ class GreedyMap:
                 sorted_idx_filtered.append(idx_tuple)
         return sorted_idx_filtered
 
-    def __contradicts(self, M: List[Dict[int, int]], idx_tuple: List[int]) -> bool:
+    def _contradicts(self, M: List[Dict[int, int]], idx_tuple: List[int]) -> bool:
         """
         Check if an index tuple contradicts a matching, i.e. return True if
         any index in the tuple is already present in the matching.

--- a/dover_lap/src/mapping/hungarian.py
+++ b/dover_lap/src/mapping/hungarian.py
@@ -1,12 +1,10 @@
 import numpy as np
-import sys
 
 from typing import List, Dict, Tuple, Optional
-from scipy.optimize import linear_sum_assignment
 
-from dover_lap.libs.utils import groupby, info
+from dover_lap.libs.utils import groupby
 from dover_lap.libs.turn import Turn, merge_turns
-import spyder
+from spyder import DER
 
 from .map_utils import *
 
@@ -24,7 +22,7 @@ class HungarianMap:
         """
         self.turns_list = turns_list
 
-        weights = self.__compute_weights()
+        weights = self._compute_weights()
         self.sorted_turns_list = self.turns_list
         if self.sort_first:
             sorted_idx = weights.argsort().tolist()
@@ -35,15 +33,15 @@ class HungarianMap:
 
         for i in range(1, len(self.sorted_turns_list)):
             next_turns = self.sorted_turns_list[i]
-            local_mapping = self.__map_pair(cur_turns, next_turns)
-            cur_turns = self.__merge_pair(cur_turns, next_turns, local_mapping)
-            self.__update_global_map(local_mapping)
+            local_mapping = self._map_pair(cur_turns, next_turns)
+            cur_turns = self._merge_pair(cur_turns, next_turns, local_mapping)
+            self._update_global_map(local_mapping)
 
-        if not self.__validate_global_mapping():
+        if not self._validate_global_mapping():
             raise Exception("Some speakers have not been mapped")
         return self.global_mapping, weights
 
-    def __validate_global_mapping(self) -> bool:
+    def _validate_global_mapping(self) -> bool:
         for i, turns in enumerate(self.sorted_turns_list):
             groups = {
                 key: list(group)
@@ -54,7 +52,7 @@ class HungarianMap:
                     return False
         return True
 
-    def __compute_weights(self) -> np.ndarray:
+    def _compute_weights(self) -> np.ndarray:
         N = len(self.turns_list)
         DERs = np.zeros((N, N))
         for i in range(N):
@@ -67,63 +65,28 @@ class HungarianMap:
                     (turn.speaker_id, turn.onset, turn.offset)
                     for turn in self.turns_list[j]
                 ]
-                DERs[i, j] = spyder.DER(ref, hyp).der
+                DERs[i, j] = DER(ref, hyp).der
         mean_ders = DERs.mean(axis=0)
         return -1 * mean_ders
 
-    def __map_pair(
+    def _map_pair(
         self, ref_turns: List[Turn], sys_turns: List[Turn]
     ) -> Dict[Tuple[int, str], int]:
-        ref_groups = {
-            key: list(group)
-            for key, group in groupby(ref_turns, lambda x: x.speaker_id)
-        }
-        sys_groups = {
-            key: list(group)
-            for key, group in groupby(sys_turns, lambda x: x.speaker_id)
-        }
-        ref_keys = sorted(ref_groups.keys())
-        sys_keys = sorted(sys_groups.keys())
-        M, N = len(ref_keys), len(sys_keys)
-        cost_matrix = np.zeros((M, N))
-        for i, ref_spk_id in enumerate(ref_keys):
-            cur_row = []
-            ref_spk_turns = ref_groups[ref_spk_id]
-            for j, sys_spk_id in enumerate(sys_keys):
-                sys_spk_turns = sys_groups[sys_spk_id]
-                total_overlap = compute_spk_overlap(ref_spk_turns, sys_spk_turns)
-                cost_matrix[i, j] = -1 * total_overlap
+        ref = [(turn.speaker_id, turn.onset, turn.offset) for turn in ref_turns]
+        sys = [(turn.speaker_id, turn.onset, turn.offset) for turn in sys_turns]
+        metrics = DER(ref, sys)
+        ref_map = metrics.ref_map
+        sys_map = metrics.hyp_map
 
-        row_ind, col_ind = linear_sum_assignment(cost_matrix)
-
-        # Keep track of remaining row or col indices
-        row_indices_remaining = list(range(M))
-        col_indices_remaining = list(range(N))
         label_mapping = {}
-
-        for i in range(len(row_ind)):
-            label_mapping[(0, ref_keys[row_ind[i]])] = i
-            row_indices_remaining.remove(row_ind[i])
-            label_mapping[(1, sys_keys[col_ind[i]])] = i
-            col_indices_remaining.remove(col_ind[i])
-
-        next_label = i + 1
-
-        # Assign labels to remaining row indices
-        while len(row_indices_remaining) != 0:
-            label_mapping[(0, ref_keys[row_indices_remaining[0]])] = next_label
-            next_label += 1
-            del row_indices_remaining[0]
-
-        # Assign labels to remaining col indices
-        while len(col_indices_remaining) != 0:
-            label_mapping[(1, sys_keys[col_indices_remaining[0]])] = next_label
-            next_label += 1
-            del col_indices_remaining[0]
+        for k, v in ref_map.items():
+            label_mapping[(0, k)] = v
+        for k, v in sys_map.items():
+            label_mapping[(1, k)] = v
 
         return label_mapping
 
-    def __merge_pair(
+    def _merge_pair(
         self,
         ref_turns: List[Turn],
         sys_turns: List[Turn],
@@ -148,7 +111,7 @@ class HungarianMap:
         all_turns = merge_turns(ref_turns_mapped + sys_turns_mapped)
         return all_turns
 
-    def __update_global_map(self, local_map: Dict[Tuple[int, str], int]) -> None:
+    def _update_global_map(self, local_map: Dict[Tuple[int, str], int]) -> None:
         if not self.global_mapping:
             self.global_mapping = local_map.copy()
             return

--- a/dover_lap/src/mapping/map_utils.py
+++ b/dover_lap/src/mapping/map_utils.py
@@ -1,13 +1,7 @@
-import sys
-import random
+from typing import List, Dict, Tuple
 
-from typing import List, Dict, Tuple, Optional
-from collections import defaultdict
-
-from dover_lap.libs.utils import groupby, info
+from dover_lap.libs.utils import groupby
 from dover_lap.libs.turn import Turn
-
-import numpy as np
 
 
 def compute_spk_overlap(ref_spk_turns: List[Turn], sys_spk_turns: List[Turn]) -> float:

--- a/dover_lap/src/voting/__init__.py
+++ b/dover_lap/src/voting/__init__.py
@@ -1,0 +1,1 @@
+from .average import WeightedAverageVoting

--- a/dover_lap/src/voting/average.py
+++ b/dover_lap/src/voting/average.py
@@ -1,0 +1,52 @@
+from typing import Optional, List
+
+import numpy as np
+from scipy.stats import rankdata
+
+from dover_lap.libs.turn import Turn
+
+
+class WeightedAverageVoting:
+    def __init__(self) -> None:
+        pass
+
+    def get_combined_turns(
+        self, regions: np.ndarray, start_end: np.ndarray, file_id: str
+    ) -> List[Turn]:
+        """
+        Implements combination using the DOVER-Lap weighted average voting method.
+
+        :param regions, matrix of shape (num_regions, num_speakers), where each row
+            represents a homogeneous time region, and each column represents a speaker.
+            The value in each cell represents the weight of the speaker in that region.
+        :param start_end, list of start and end times for each region
+        """
+        assert (
+            regions.shape[0] == start_end.shape[0]
+        ), "Regions and start_end must have the same number of rows"
+
+        # Get the number of speakers in each region
+        num_spks = np.sum(regions, axis=1).round().astype(int)
+
+        # Rank the weights in each region. We use the min method to break ties. This
+        # means that if two speakers have the same weight, they will be assigned the
+        # rank of the lower speaker. Note that we negate the regions matrix because
+        # rankdata() sorts in ascending order.
+        spk_ranks_matrix = rankdata(-1 * regions, axis=1, method="min")
+
+        # Create turns list by combining the regions and start_end
+        combined_turns_list = []
+        for i in range(len(spk_ranks_matrix)):
+            start_time, end_time = start_end[i]
+            spk_ranks = spk_ranks_matrix[i]
+            for j, spk_rank in enumerate(spk_ranks):
+                if spk_rank <= num_spks[i]:
+                    turn = Turn(
+                        onset=start_time,
+                        offset=end_time,
+                        speaker_id=j,
+                        file_id=file_id,
+                    )
+                    combined_turns_list.append(turn)
+
+        return combined_turns_list

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ intervaltree>=3.0.1
 numpy>=1.18.1
 click>=7.1.2
 scipy>=1.5.4
-spy-der>=0.1.0
+spy-der>=0.4.0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ dev_requires = ["pre-commit", "black", "flake8"]
 
 setup(
     name="dover-lap",
-    version="1.1.0",
+    version="1.2.0",
     author="Desh Raj",
     author_email="r.desh26@gmail.com",
     description="Combine overlap-aware diarization output RTTMs",


### PR DESCRIPTION
This PR includes several quality-of-life changes. It shouldn't effect DER performance overall.

1. Remove `--tie-breaking` option. It is well established now that tied speakers should all be included in the combined output.
2. Restructure code so that "voting methods" have their own sub directory, similar to "mapping methods". Allows to add more voting techniques in future.
3. Remove unused imports from several files.
4. Vectorize the average voting instead of iterating.
5. Use `spyder` for label mapping instead of scipy.