### PR TITLE
More changes for v1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,6 @@ Options:
                                   of the maximal matching for greedy label
                                   mapping  [default: False]
 
-  --sort-first                    If this flag is set, sort inputs by DER
-                                  first before label mapping (only applicable
-                                  when label mapping type is hungarian)
-                                  [default: False]
-
   --label-mapping [hungarian|greedy]
                                   Choose label mapping algorithm to use
                                   [default: greedy]
@@ -93,7 +88,8 @@ _* The Greedy label mapping is exponential in number of inputs (see [this paper]
 
 The algorithm is implemented in pure Python with NumPy for tensor computations. 
 The time complexity is expected to increase exponentially with the number of 
-inputs, but it should be reasonable for combining up to 10 input hypotheses.
+inputs, but it should be reasonable for combining up to 10 input hypotheses. For 
+combining more than 10 inputs, we recommend setting `--label-mapping hungarian`.
 
 For smaller number of inputs (up to 5), the algorithm should take only a few seconds
 to run on a laptop.
@@ -104,8 +100,8 @@ DOVER-Lap is meant to be used to combine **more than 2 systems**, since
 black-box voting between 2 systems does not make much sense. Still, if 2 systems
 are provided as input, we fall back on the Hungarian algorithm for label mapping,
 since it is provably optimal for this case. Both the systems are assigned equal
-weights, and in case of voting conflicts, the region is equally divided among the
-two labels. This is not the intended use case and will almost certainly lead
+weights, and in case of voting conflicts, the region is assigned to both
+labels. This is not the intended use case and will almost certainly lead
 to performance degradation.
 
 ## Citation

--- a/dover_lap/dover_lap.py
+++ b/dover_lap/dover_lap.py
@@ -66,14 +66,6 @@ def load_rttms(rttm_list: List[str]) -> List[List[Turn]]:
     help="Choose label mapping algorithm to use",
 )
 @click.option(
-    "--sort-first",
-    is_flag=True,
-    default=False,
-    show_default=True,
-    help="If this flag is set, sort inputs by DER first before label mapping "
-    "(only applicable when label mapping type is hungarian)",
-)
-@click.option(
     "--second-maximal",
     is_flag=True,
     default=False,

--- a/dover_lap/src/doverlap.py
+++ b/dover_lap/src/doverlap.py
@@ -14,7 +14,6 @@ class DOVERLap:
         turns_list: List[List[Turn]],
         file_id: str,
         label_mapping: Optional[str] = "greedy",
-        sort_first: Optional[bool] = False,
         second_maximal: Optional[bool] = False,
         voting_method: Optional[str] = "average",
         weight_type: Optional[str] = "rank",
@@ -28,7 +27,6 @@ class DOVERLap:
             file_id,
             method=label_mapping,
             second_maximal=second_maximal,
-            sort_first=sort_first,
         )
 
         # Compute weights based on rank

--- a/dover_lap/src/label_mapping.py
+++ b/dover_lap/src/label_mapping.py
@@ -13,7 +13,6 @@ class LabelMapping:
         turns_list: List[List[Turn]],
         file_id: str,
         method: Optional[str] = "greedy",
-        sort_first: Optional[bool] = False,
         second_maximal: Optional[bool] = False,
     ) -> List[List[Turn]]:
         """
@@ -23,7 +22,7 @@ class LabelMapping:
 
         if (len(turns_list) == 2) or (method == "hungarian"):
             # We replace the original turns list with one sorted by average DER
-            hungarian_map = HungarianMap(sort_first=sort_first)
+            hungarian_map = HungarianMap()
             label_mapping, weights = hungarian_map.compute_mapping(turns_list)
             turns_list = hungarian_map.sorted_turns_list
 

--- a/dover_lap/src/mapping/hungarian.py
+++ b/dover_lap/src/mapping/hungarian.py
@@ -10,8 +10,8 @@ from .map_utils import *
 
 
 class HungarianMap:
-    def __init__(self, sort_first: Optional[bool] = True) -> None:
-        self.sort_first = sort_first
+    def __init__(self) -> None:
+        pass
 
     def compute_mapping(
         self,
@@ -24,9 +24,9 @@ class HungarianMap:
 
         weights = self._compute_weights()
         self.sorted_turns_list = self.turns_list
-        if self.sort_first:
-            sorted_idx = weights.argsort().tolist()
-            self.sorted_turns_list = [self.turns_list[i] for i in sorted_idx]
+        # Sort the hypotheses by their weights
+        sorted_idx = weights.argsort().tolist()
+        self.sorted_turns_list = [self.turns_list[i] for i in sorted_idx]
 
         cur_turns = self.sorted_turns_list[0]
         self.global_mapping = dict()


### PR DESCRIPTION
`--sort-first` always gives better results for Hungarian label mapping, so we include it by default. Example results:

| Dataset  | No sort | With sort |
|----------|---------|-----------|
| AMI      |   20.84 |     20.73 |
| LibriCSS |    4.81 |      4.65 |